### PR TITLE
8196 move getConnection into a try block

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -149,8 +149,8 @@ abstract class DefaultDatabase(val name: String, configuration: Config, environm
   }
 
   def withConnection[A](autocommit: Boolean)(block: Connection => A): A = {
-    val connection = getConnection(autocommit)
     try {
+      val connection = getConnection(autocommit)
       block(connection)
     } finally {
       connection.close()


### PR DESCRIPTION
# 課題
> Databases:148 calls line 152, which calls line:142. You can see that line 153 sets up a try-finally block, but the connection aquisition occurs outside of that block. That would be fine if getConnection() actually did only that. However, line 143 can throw after the connection is borrowed, but before the try-finally, causing the connection to be leaked.

141行目のメソッドの 'getConnection' メソッドで例外が投げられるが、tryブロックの外なので例外が投げられた際にコネクションがクローズしない。

# 解決策
getConnection メソッドをtry構文の中で呼び出す。これならキャッチすることができるので、例外を投げたときにコネクションをクローズすることができる。